### PR TITLE
♻️: improve import order

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
-mod slipmux;
-mod tui;
+use std::sync::mpsc;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use std::thread;
+use std::time::Duration;
 
 use slipmux::read_thread;
 use tui::show;
 
-use std::sync::mpsc;
-use std::sync::mpsc::{Receiver, Sender};
-use std::thread;
-use std::time::Duration;
+mod slipmux;
+mod tui;
 
 fn main() {
     let (diagnostic_tx, diagnostic_rx): (Sender<String>, Receiver<String>) = mpsc::channel();

--- a/src/slipmux.rs
+++ b/src/slipmux.rs
@@ -1,7 +1,10 @@
-use coap_lite::Packet;
-use serial_line_ip::{Decoder, Encoder};
-use serialport::SerialPort;
 use std::sync::mpsc::Sender;
+
+use coap_lite::Packet;
+use serial_line_ip::Decoder;
+use serial_line_ip::Encoder;
+use serialport::SerialPort;
+
 const DIAGNOSTIC: u8 = 0x0a;
 const CONFIGURATION: u8 = 0xA9;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,20 +1,26 @@
+use std::sync::mpsc;
+use std::sync::mpsc::Receiver;
+use std::time::Duration;
+use std::time::Instant;
+
 use coap_lite::CoapOption;
 use coap_lite::CoapRequest;
 use coap_lite::ContentFormat;
 use coap_lite::MessageClass;
-use coap_lite::{Packet, RequestType as Method};
+use coap_lite::Packet;
+use coap_lite::RequestType as Method;
 use crossterm::event::Event;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
-use ratatui::prelude::Alignment;
-use ratatui::prelude::Backend;
-use ratatui::prelude::Constraint;
-use ratatui::prelude::CrosstermBackend;
-use ratatui::prelude::Direction;
-use ratatui::prelude::Layout;
-use ratatui::prelude::Span;
-use ratatui::prelude::Text;
+use ratatui::backend::Backend;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::text::Span;
+use ratatui::text::Text;
 use ratatui::widgets::Block;
 use ratatui::widgets::BorderType;
 use ratatui::widgets::List;
@@ -23,11 +29,6 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 use ratatui::Terminal;
 use serialport::SerialPort;
-
-use std::sync::mpsc;
-use std::sync::mpsc::Receiver;
-use std::time::Duration;
-use std::time::Instant;
 
 use crate::slipmux::send_configuration;
 use crate::slipmux::send_diagnostic;


### PR DESCRIPTION
On the nightly rustfmt there is a neat [`imports_granularity` config](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#imports_granularity).

```bash
cargo +nightly fmt -- --config imports_granularity=Item
```

rust-analyzer also has something like that when imports are automatically added (I personally prefer `Module` over `Item`):

https://github.com/EdJoPaTo/LinuxScripts/blob/a21d4c734d7b318d83ef9dcfc4be19f60c4c46df/configs/vscode-settings.json#L27