### PR TITLE
🐛: Handle resource `/` correctly

### DIFF
--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -174,7 +174,11 @@ impl App<'_> {
                     if self.user_command.starts_with('/') {
                         let mut request: CoapRequest<String> = CoapRequest::new();
                         request.set_method(Method::Get);
-                        request.set_path(&self.user_command);
+                        if self.user_command != "/" {
+                            // Might also be a bug in coap-lite that "/" should be turned into an
+                            // empty option set; documentation isn't quite conclusive.
+                            request.set_path(&self.user_command);
+                        }
                         request.message.set_token(self.get_new_token());
                         request.message.add_option(CoapOption::Block2, vec![0x05]);
                         let (data, size) =

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -253,9 +253,12 @@ fn fmt_packet(packet: &Packet) -> String {
         MessageClass::Empty => _ = write!(out, "Empty"),
         MessageClass::Request(rtype) => {
             _ = write!(out, " ← Req({rtype:?} ");
-            let option_list = packet.get_option(CoapOption::UriPath).unwrap();
-            for option in option_list {
-                _ = write!(out, "/{}", String::from_utf8_lossy(option));
+            if let Some(option_list) = packet.get_option(CoapOption::UriPath) {
+                for option in option_list {
+                    _ = write!(out, "/{}", String::from_utf8_lossy(option));
+                }
+            } else {
+                _ = write!(out, "/");
             }
             _ = write!(
                 out,

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -64,11 +64,6 @@ impl App<'_> {
         let total_length: u16 = {
             let mut sum = 0;
             for req in &self.configuration_requests {
-                let option_list_ = req.message.get_option(CoapOption::UriPath).unwrap();
-                let mut uri_path = String::new();
-                for option in option_list_ {
-                    _ = write!(uri_path, "{}", String::from_utf8_lossy(option));
-                }
                 let block = Block::new()
                     .borders(Borders::TOP | Borders::BOTTOM)
                     .style(Style::new().gray())


### PR DESCRIPTION
While coap://foo and coap://foo/ are equivalent under schema-aware normalization, their CoAP encoding is not (as this crate and possibly even coap-lite assumed) a single empty Uri-Path option, but no Uri-Path option at all.

Not sure which Emoji would best go with this PR -- ⚡ ?

## Testing

To test, this needs a CoAP server that is strict with trailing empty CoAP options; not all are. The Ariel OS CoAP server, when accessed through https://codeberg.org/chrysn/ariel-slipmux-shim (its docs have a very minimal setup guide) provides such a server; enter `/` in Jelly to see the difference.
