### PR TITLE
🐛: Rework payload printing to avoid crash or "empty message"

### DIFF
--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -267,30 +267,29 @@ fn fmt_packet(packet: &Packet) -> String {
             );
         }
         MessageClass::Response(rtype) => {
-            _ = write!(out, " → Res({rtype:?}");
-            if let Some(cf) = packet.get_content_format() {
-                let payload = match cf {
-                    ContentFormat::ApplicationLinkFormat => {
+            let cf = packet.get_content_format();
+            let payload_formatted = match (cf, &packet.payload) {
+                (Some(ContentFormat::ApplicationLinkFormat), payload) => {
                         // change me back | ContentFormat::TextPlain
-                        String::from_utf8_lossy(&packet.payload).replace(',', "\n  ")
-                    }
-                    ContentFormat::TextPlain => {
-                        String::from_utf8_lossy(&packet.payload).to_string()
-                    }
-                    _ => todo!(),
+                        String::from_utf8_lossy(payload).replace(',', "\n  ")
+                    },
+                (Some(ContentFormat::TextPlain), payload) =>
+                        String::from_utf8_lossy(payload).to_string(),
+                // this is a cheap-in-terms-of-dependencies hex formatting; `aa bb cc` would be
+                // prettier than `[aa, bb, cc]`, but needs extra dependencies.
+                (_, payload) => format!("{payload:02x?}"),
                 };
-                _ = write!(
-                    out,
-                    "/{cf:?})[0x{:04x}] {:} bytes\n  {payload}",
-                    u16::from_le_bytes(packet.get_token().try_into().unwrap_or([0xff, 0xff])),
-                    payload.len()
-                );
+            let slash_cf = cf.map(|c| format!("{c:?}")).unwrap_or_default();
+            _ = write!(out, "");
+            _ = write!(
+                out,
+                " → Res({rtype:?}{slash_cf})[0x{:04x}]",
+                u16::from_le_bytes(packet.get_token().try_into().unwrap_or([0xff, 0xff])),
+            );
+            if packet.payload.is_empty() {
+                _ = write!(out, "\n  Empty Payload");
             } else {
-                _ = write!(
-                    out,
-                    ")[0x{:04x}]\n  Empty Payload",
-                    u16::from_le_bytes(packet.get_token().try_into().unwrap_or([0xff, 0xff]))
-                );
+                _ = write!(out, ": {} bytes\n  {payload_formatted}", packet.payload.len());
             }
         }
         MessageClass::Reserved(_) => _ = write!(out, "Reserved"),


### PR DESCRIPTION
This fixes two issues in a single refactor:

* Responses with payload and no media type used to be shown as "empty message", even though they do contain payload.
* Unknown media types used to lead to a crash.

Unknown or absent media types are now shown as hex-ish data.

<del>There's some bug left in there that leads to the newlines in .well-known/core files not being shown; maybe I'll add that on here later.</del> [edit: turned out that's a source issue, [fixed in upcoming versions](https://codeberg.org/chrysn/coap-tools/pulls/26)]