### PR TITLE
🐛: Restore response formatting

### DIFF
--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -281,7 +281,7 @@ fn fmt_packet(packet: &Packet) -> String {
                 // prettier than `[aa, bb, cc]`, but needs extra dependencies.
                 (_, payload) => format!("{payload:02x?}"),
             };
-            let slash_cf = cf.map(|c| format!("{c:?}")).unwrap_or_default();
+            let slash_cf = cf.map(|c| format!("/{c:?}")).unwrap_or_default();
             _ = write!(out, "");
             _ = write!(
                 out,


### PR DESCRIPTION
This slash got lost in e77b6e43, leading to oddly concatenated texts.

Maybe I should sleep more, starting that now.