### PR TITLE
Pin Jelly to Rust version 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "A tool to interact with a shell via Slipmux"
 version = "0.1.0"
 edition = "2021"
 authors = ["Bennet Hattesen <bennet.hattesen@haw-hamburg.de>"]
+rust-version = "1.89"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89"
+components = [ "rustfmt", "clippy" ]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,10 @@
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
-format_code_in_doc_comments = true
-format_macro_matchers = true
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-normalize_doc_attributes = true
-reorder_impl_items = true
+# == These require the nightly channel ==
+# format_code_in_doc_comments = true
+# format_macro_matchers = true
+# group_imports = "StdExternalCrate"
+# imports_granularity = "Item"
+# normalize_doc_attributes = true
+# reorder_impl_items = true
+
 use_field_init_shorthand = true

--- a/src/app/datatypes.rs
+++ b/src/app/datatypes.rs
@@ -320,7 +320,7 @@ impl Response {
         format!("[{}]", dt.format("%H:%M:%S%.3f"))
     }
 
-    fn get_status(&self) -> Span {
+    fn get_status(&self) -> Span<'_> {
         let status = self.coap.get_status();
         let token = token_to_u64(self.coap.message.get_token());
         let bytes = self.coap.message.payload.len();
@@ -337,7 +337,7 @@ impl Response {
         }
     }
 
-    fn get_status_short(&self) -> Span {
+    fn get_status_short(&self) -> Span<'_> {
         let status = self.coap.get_status();
 
         let response_summary = self.coap.message.get_content_format().map_or_else(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -278,7 +278,7 @@ impl UserInputManager {
         self.user_input.is_empty()
     }
 
-    fn classify_input(&self) -> InputType {
+    fn classify_input(&self) -> InputType<'_> {
         let (cmd_string, file) = if let Some((cmd_string, path)) = self.user_input.split_once("%>")
         {
             (cmd_string, SaveToFile::AsBin(path.trim().to_owned()))


### PR DESCRIPTION
:penguin: 

This pins Jelly to stable Rust 1.89
This is done to keep CI toolchain & developer machines in sync.
Beside some optional rustfmt rules, no unstable features are needed, hence a stable version is chosen.