### PR TITLE
♻️: Refactor overall

### DIFF
--- a/src/app/datatypes.rs
+++ b/src/app/datatypes.rs
@@ -22,7 +22,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 
 use crate::app::CoapOption;
-use crate::commands::CommandHandler;
+use crate::command::CommandHandler;
 
 pub enum SaveToFile {
     No,

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -20,7 +20,7 @@ use crate::app::App;
 use crate::app::InputType;
 use crate::app::Job;
 use crate::app::Request;
-use crate::commands::Command;
+use crate::command::Command;
 use crate::events::Event;
 
 impl App {

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -15,7 +15,7 @@ use slipmux::Slipmux;
 
 use super::datatypes::token_to_u64;
 use super::datatypes::Response;
-use super::SelectedTab;
+
 use crate::app::App;
 use crate::app::InputType;
 use crate::app::Job;
@@ -66,7 +66,7 @@ impl App {
 
     pub fn on_connect(&mut self, name: String) {
         self.connected = true;
-        self.ui_state.device_path = Some(name);
+        self.ui_state.set_device_path(name);
 
         let mut request: CoapRequest<String> = Self::build_get_request("/.well-known/core");
         self.send_configuration_request(&mut request.message);
@@ -83,7 +83,7 @@ impl App {
 
     pub fn on_disconnect(&mut self) {
         self.connected = false;
-        self.ui_state.device_path = None;
+        self.ui_state.clear_device_path();
     }
 
     fn handle_pending_job(&mut self, mut hash_index: u64, payload: &[u8]) {
@@ -289,19 +289,19 @@ impl App {
                 self.user_input_manager.insert_char(to_insert);
             }
             KeyCode::F(1) => {
-                self.ui_state.current_tab = SelectedTab::Overview;
+                self.ui_state.select_overview_view();
             }
             KeyCode::F(2) => {
-                self.ui_state.current_tab = SelectedTab::Diagnostic;
+                self.ui_state.select_diagnostic_view();
             }
             KeyCode::F(3) => {
-                self.ui_state.current_tab = SelectedTab::Configuration;
+                self.ui_state.select_configuration_view();
             }
             KeyCode::F(4) => {
-                self.ui_state.current_tab = SelectedTab::Commands;
+                self.ui_state.select_commands_view();
             }
             KeyCode::F(5) => {
-                self.ui_state.current_tab = SelectedTab::Help;
+                self.ui_state.select_help_view();
             }
             KeyCode::Esc => {
                 return false;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,9 +8,9 @@ use coap_lite::RequestType as Method;
 use datatypes::DiagnosticLog;
 use datatypes::JobLog;
 use rand::Rng;
+use ratatui::Frame;
 use slipmux::encode_buffered;
 use slipmux::Slipmux;
-use tui_widgets::scrollview::ScrollViewState;
 
 use crate::app::datatypes::Job;
 use crate::app::datatypes::Request;
@@ -18,154 +18,17 @@ use crate::app::datatypes::SaveToFile;
 use crate::command::Command;
 use crate::command::CommandLibrary;
 use crate::events::Event;
+use crate::tui::UiState;
 
-mod datatypes;
+pub mod datatypes;
 mod handler;
-mod tui;
 
-#[derive(Default, Clone, Copy)]
-enum SelectedTab {
-    #[default]
-    Overview,
-    Diagnostic,
-    Configuration,
-    Commands,
-    Help,
-}
-
-struct ScrollState {
-    state: ScrollViewState,
-    position: usize,
-    follow: bool,
-}
-
-impl ScrollState {
-    fn new() -> Self {
-        Self {
-            state: ScrollViewState::default(),
-            position: 0,
-            follow: true,
-        }
-    }
-
-    fn scroll_down(&mut self) {
-        self.position = self.position.saturating_sub(1);
-        // When scrolled all the way to the bottom, auto follow the feed ("sticky behavior")
-        self.follow = self.position == 0;
-        self.state.scroll_down();
-    }
-
-    fn scroll_up(&mut self) {
-        self.follow = false;
-        // Can't scroll up when already on top
-        if self.state.offset().y != 0 {
-            self.position = self.position.saturating_add(1);
-        }
-        self.state.scroll_up();
-    }
-
-    fn get_state_for_rendering(&mut self) -> &mut ScrollViewState {
-        // For the "sticky" behavior, where the view remains at the bottom
-        // Needs to be done during rendering as more content could have been added, making
-        // a jump to the bottom necessary
-        if self.follow {
-            self.state.scroll_to_bottom();
-        }
-
-        &mut self.state
-    }
-}
-
-struct UiState {
-    device_path: Option<String>,
-    overview_scroll: ScrollState,
-    diagnostic_scroll: ScrollState,
-    configuration_scroll: ScrollState,
-    command_scroll: ScrollState,
-    help_scroll: ScrollState,
-    current_tab: SelectedTab,
-    riot_board: String,
-    riot_version: String,
-}
-
-impl UiState {
-    fn new() -> Self {
-        Self {
-            device_path: None,
-
-            current_tab: SelectedTab::Overview,
-
-            overview_scroll: ScrollState::new(),
-            diagnostic_scroll: ScrollState::new(),
-            configuration_scroll: ScrollState::new(),
-            command_scroll: ScrollState::new(),
-            help_scroll: ScrollState::new(),
-
-            riot_board: "Unkown".to_owned(),
-            riot_version: "Unkown".to_owned(),
-        }
-    }
-
-    fn set_board_name(&mut self, name: String) {
-        self.riot_board = name;
-    }
-
-    fn set_board_version(&mut self, version: String) {
-        self.riot_version = version;
-    }
-
-    fn get_config(&self) -> String {
-        format!(
-            "Version: {}\nBoard: {}\n",
-            self.riot_version, self.riot_board,
-        )
-    }
-
-    fn get_connection(&self) -> String {
-        match &self.device_path {
-            Some(device_path) => {
-                format!(
-                    "✅ connected via {device_path} with RIOT {}",
-                    self.riot_version
-                )
-            }
-            None => "❌ not connected, retrying..".to_owned(),
-        }
-    }
-
-    fn scroll_down(&mut self) {
-        match self.current_tab {
-            SelectedTab::Overview => {
-                self.overview_scroll.scroll_down();
-                self.configuration_scroll.scroll_down();
-            }
-            SelectedTab::Diagnostic => self.diagnostic_scroll.scroll_down(),
-            SelectedTab::Configuration => self.configuration_scroll.scroll_down(),
-            SelectedTab::Commands => self.command_scroll.scroll_down(),
-            SelectedTab::Help => self.help_scroll.scroll_down(),
-        }
-    }
-
-    fn scroll_up(&mut self) {
-        match self.current_tab {
-            SelectedTab::Overview => {
-                self.overview_scroll.scroll_up();
-                self.configuration_scroll.scroll_up();
-            }
-            SelectedTab::Diagnostic => self.diagnostic_scroll.scroll_up(),
-            SelectedTab::Configuration => self.configuration_scroll.scroll_up(),
-            SelectedTab::Commands => self.command_scroll.scroll_up(),
-            SelectedTab::Help => self.help_scroll.scroll_up(),
-        }
-    }
-}
-
-struct UserInputManager {
+pub struct UserInputManager {
     known_commands: CommandLibrary,
-    user_input: String,
+    pub user_input: String,
     user_command_history: Vec<String>,
     user_command_history_index: usize,
-    cursor_position: usize,
+    pub cursor_position: usize,
 }
 
 enum InputType<'a> {
@@ -217,7 +80,7 @@ impl UserInputManager {
         }
     }
 
-    fn suggestion(&self) -> (String, Vec<&Command>) {
+    pub fn suggestion(&self) -> (String, Vec<&Command>) {
         self.known_commands
             .longest_common_prefixed_by_cmd(&self.user_input)
     }
@@ -274,7 +137,7 @@ impl UserInputManager {
         self.user_command_history_index = self.user_command_history.len();
     }
 
-    const fn input_empty(&self) -> bool {
+    pub const fn input_empty(&self) -> bool {
         self.user_input.is_empty()
     }
 
@@ -312,7 +175,7 @@ impl UserInputManager {
         }
     }
 
-    fn command_name_list(&self) -> String {
+    pub fn command_name_list(&self) -> String {
         self.known_commands.list_by_cmd().join(", ")
     }
 
@@ -406,5 +269,16 @@ impl App {
         self.event_sender
             .send(Event::SendConfiguration(data))
             .unwrap();
+    }
+
+    pub fn draw(&mut self, frame: &mut Frame) {
+        self.ui_state.draw(
+            frame,
+            &self.user_input_manager,
+            &self.job_log,
+            &self.configuration_log,
+            &self.diagnostic_log,
+            &self.overall_log,
+        );
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,8 +15,8 @@ use tui_widgets::scrollview::ScrollViewState;
 use crate::app::datatypes::Job;
 use crate::app::datatypes::Request;
 use crate::app::datatypes::SaveToFile;
-use crate::commands::Command;
-use crate::commands::CommandLibrary;
+use crate::command::Command;
+use crate::command::CommandLibrary;
 use crate::events::Event;
 
 mod datatypes;

--- a/src/command/commands/coap_get_template.rs
+++ b/src/command/commands/coap_get_template.rs
@@ -1,9 +1,9 @@
 use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
 
-use crate::commands::Command;
-use crate::commands::CommandHandler;
-use crate::commands::CommandRegistry;
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
 
 /// This is a template command. It shows the minimum setup for making a
 /// CoAP GET request to a single endpoint. The result is not displayed to the user.

--- a/src/command/commands/mem.rs
+++ b/src/command/commands/mem.rs
@@ -7,9 +7,9 @@ use coap_message::MinimalWritableMessage;
 use minicbor::Decoder;
 use minicbor::Encoder;
 
-use crate::commands::Command;
-use crate::commands::CommandHandler;
-use crate::commands::CommandRegistry;
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
 
 /// Taken and modified from Alex Martens's clap-num
 /// <https://github.com/newAM/clap-num/blob/c6f1065f87f319098943aae75412a0c38c85f11c/src/lib.rs#L347-L384>

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -1,0 +1,26 @@
+pub use coap_get_template::CoapGet;
+use mem::MemRead;
+use multi_endpoints_sample::MultiEndpointSample;
+use sample::SampleCommand;
+use saul::Saul;
+pub use wkc::Wkc;
+
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
+
+mod coap_get_template;
+mod mem;
+mod multi_endpoints_sample;
+mod sample;
+mod saul;
+mod wkc;
+
+pub fn all_commands() -> Vec<Command> {
+    vec![
+        SampleCommand::cmd(),
+        Saul::cmd(),
+        MultiEndpointSample::cmd(),
+        MemRead::cmd(),
+    ]
+}

--- a/src/command/commands/multi_endpoints_sample.rs
+++ b/src/command/commands/multi_endpoints_sample.rs
@@ -3,9 +3,9 @@ use std::fmt::Write;
 use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
 
-use crate::commands::Command;
-use crate::commands::CommandHandler;
-use crate::commands::CommandRegistry;
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
 
 /// This is an example for writing a command that needs to issue multiple CoAP requests and
 /// keep track of the state while doing so.

--- a/src/command/commands/sample.rs
+++ b/src/command/commands/sample.rs
@@ -6,9 +6,9 @@ use coap_lite::RequestType as Method;
 use coap_message::MinimalWritableMessage;
 use minicbor::Encoder;
 
-use crate::commands::Command;
-use crate::commands::CommandHandler;
-use crate::commands::CommandRegistry;
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
 
 #[derive(Parser, Debug)]
 #[command(name = "SampleCommand")]

--- a/src/command/commands/saul.rs
+++ b/src/command/commands/saul.rs
@@ -8,9 +8,9 @@ use coap_message::MinimalWritableMessage;
 use minicbor::Decoder;
 use minicbor::Encoder;
 
-use crate::commands::Command;
-use crate::commands::CommandHandler;
-use crate::commands::CommandRegistry;
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
 
 /// This is an example on how to use cbor as payload for the coap request.
 #[derive(Parser, Debug)]

--- a/src/command/commands/wkc.rs
+++ b/src/command/commands/wkc.rs
@@ -3,9 +3,9 @@ use std::fmt::Write;
 use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
 
-use crate::commands::Command;
-use crate::commands::CommandHandler;
-use crate::commands::CommandRegistry;
+use super::Command;
+use super::CommandHandler;
+use super::CommandRegistry;
 
 /// Explicit example for a command that queries the well-known/core. Could have been done
 /// using the template command, but explicit for demonstration.

--- a/src/command/library.rs
+++ b/src/command/library.rs
@@ -1,0 +1,138 @@
+use super::commands::all_commands;
+use super::commands::Wkc;
+use super::Command;
+use super::CommandRegistry;
+
+/// The command library maintains all known commands and provides easy access to them
+pub struct CommandLibrary {
+    /// Available commands
+    cmds: Vec<Command>,
+    /// Known commands
+    stored_cmds: Vec<Command>,
+}
+impl CommandLibrary {
+    /// Create a new library with only the two default commands included
+    /// - help: Prints all available commands
+    /// - /.well-known/core: Query the wkc
+    pub fn default() -> Self {
+        Self {
+            cmds: vec![
+                Command::new("help", "Prints all available commands"),
+                Command::from_coap_resource("/.well-known/core", "Query the wkc"),
+                Wkc::cmd(),
+            ],
+            stored_cmds: all_commands(),
+        }
+    }
+
+    /// Takes a list of endpoints that are available, this is typically the list received
+    /// from /.well-known/core, goes through all `.stored_cmds` and sees if of any of them
+    /// the requirements are met. If so, they are added to the available `.cmds`
+    /// Finally, the available `.cmds` are re-sorted.
+    pub fn update_available_cmds_based_on_endpoints(&mut self, eps: &[String]) {
+        let mut i = 0;
+        while i < self.stored_cmds.len() {
+            let scmd = &self.stored_cmds[i];
+            // Todo: Commands should be able to decide on their own if they are available
+            if scmd.required_endpoints.iter().all(|ep| eps.contains(ep)) {
+                self.cmds.push(self.stored_cmds.remove(i));
+            } else {
+                i += 1;
+            }
+        }
+
+        self.cmds.sort();
+    }
+
+    /// Returns a list of the `Command.cmd` of all known `Command`s
+    pub fn list_by_cmd(&self) -> Vec<String> {
+        self.cmds.iter().map(|x| x.cmd.clone()).collect()
+    }
+
+    /// Adds a `Command`
+    pub fn add(&mut self, cmd: Command) {
+        self.cmds.push(cmd);
+    }
+
+    /// Returns all `Command`s whos `.cmd` matches the given prefix
+    pub fn matching_prefix_by_cmd(&self, prefix: &str) -> Vec<&Command> {
+        self.cmds
+            .iter()
+            .filter(|known_cmd| known_cmd.starts_with(prefix))
+            .collect()
+    }
+
+    /// Takes a given prefix, computes all `Command`s that match it.
+    /// The prefix is then prolonged as long as the list of matching `Command`s stays identical
+    /// For example if the given prefix `F` matches `FooBar`, `FooBaz` and `FooBizz`, this
+    /// function would return '`(FooB, [FooBar, FooBaz, FooBizz])`'
+    pub fn longest_common_prefixed_by_cmd(&self, prefix: &str) -> (String, Vec<&Command>) {
+        let cmds = self.matching_prefix_by_cmd(prefix);
+
+        let actual_prefix = match cmds.len() {
+            0 => prefix.to_owned(),
+            1 => cmds[0].cmd.clone(),
+            _ => {
+                let mut common_prefix = prefix.to_owned();
+                let first_cmd = &cmds[0].cmd;
+                'outer: for (i, character) in first_cmd.chars().enumerate().skip(prefix.len()) {
+                    for othercmd in cmds.iter().skip(1) {
+                        if i >= othercmd.cmd.len() || othercmd.cmd.chars().nth(i) != Some(character)
+                        {
+                            break 'outer;
+                        }
+                    }
+                    common_prefix.push(character);
+                }
+                common_prefix
+            }
+        };
+        (actual_prefix, cmds)
+    }
+
+    /// Finds the `Command` whose `cmd` matches exactly the input
+    pub fn find_by_cmd(&self, cmd: &str) -> Option<&Command> {
+        let cmd_clean = cmd.trim_ascii_end();
+        self.cmds
+            .iter()
+            .find(|known_cmd| known_cmd.cmd == cmd_clean)
+    }
+
+    /// Finds the `Command` whose `cmd` matches exactly the input, returns mutable
+    pub fn find_by_cmd_mut(&mut self, cmd: &str) -> Option<&mut Command> {
+        let cmd_clean = cmd.trim_ascii_end();
+        self.cmds
+            .iter_mut()
+            .find(|known_cmd| known_cmd.cmd == cmd_clean)
+    }
+
+    /// Finds the `Command` whose `location` matches exactly the input
+    pub fn find_by_first_location(&self, location: &str) -> Option<&Command> {
+        self.cmds.iter().find(|known_cmd| {
+            known_cmd
+                .required_endpoints
+                .first()
+                .is_some_and(|l| l == location)
+        })
+    }
+
+    /// Same as `find_by_location` but returns a mutable
+    pub fn find_by_first_location_mut(&mut self, location: &str) -> Option<&mut Command> {
+        self.cmds.iter_mut().find(|known_cmd| {
+            known_cmd
+                .required_endpoints
+                .first()
+                .is_some_and(|l| l == location)
+        })
+    }
+
+    /// Checks is a given `Command` is already in the library
+    pub fn _contains(&self, cmd: &Command) -> bool {
+        for known_cmd in &self.cmds {
+            if known_cmd == cmd {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,20 +1,12 @@
 use std::cmp::Ordering;
 
 use coap_lite::CoapRequest;
-use mem::MemRead;
 
-use crate::commands::coap_get_template::CoapGet;
-use crate::commands::multi_endpoints_sample::MultiEndpointSample;
-use crate::commands::sample::SampleCommand;
-use crate::commands::saul::Saul;
-use crate::commands::wks::Wkc;
+use commands::all_commands;
+use commands::CoapGet;
+use commands::Wkc;
 
-mod coap_get_template;
-mod mem;
-mod multi_endpoints_sample;
-mod sample;
-mod saul;
-mod wks;
+mod commands;
 
 /// Callback API for handling a command.
 pub trait CommandHandler {
@@ -179,12 +171,7 @@ impl CommandLibrary {
                 Command::from_coap_resource("/.well-known/core", "Query the wkc"),
                 Wkc::cmd(),
             ],
-            stored_cmds: vec![
-                SampleCommand::cmd(),
-                Saul::cmd(),
-                MultiEndpointSample::cmd(),
-                MemRead::cmd(),
-            ],
+            stored_cmds: all_commands(),
         }
     }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,11 +2,11 @@ use std::cmp::Ordering;
 
 use coap_lite::CoapRequest;
 
-use commands::all_commands;
 use commands::CoapGet;
-use commands::Wkc;
+pub use library::CommandLibrary;
 
 mod commands;
+mod library;
 
 /// Callback API for handling a command.
 pub trait CommandHandler {
@@ -64,7 +64,7 @@ pub struct Command {
     /// The CoAP end-point(s) this command requires, if any.
     pub required_endpoints: Vec<String>,
 
-    /// Parses a cli string, this typically a wrapper around the `CommandRegistry::parse()` function.
+    /// Parses a cli string, this is typically a wrapper around the `CommandRegistry::parse()` function.
     ///
     /// On success, returns an implementation of the `CommandHandler` trait.
     /// On error, returns a human readable usage error.
@@ -150,139 +150,5 @@ impl Ord for Command {
                 .len()
                 .cmp(&self.required_endpoints.len()),
         }
-    }
-}
-
-/// The command library maintains all known commands and provides easy access to them
-pub struct CommandLibrary {
-    /// Available commands
-    cmds: Vec<Command>,
-    /// Known commands
-    stored_cmds: Vec<Command>,
-}
-impl CommandLibrary {
-    /// Create a new library with only the two default commands included
-    /// - help: Prints all available commands
-    /// - /.well-known/core: Query the wkc
-    pub fn default() -> Self {
-        Self {
-            cmds: vec![
-                Command::new("help", "Prints all available commands"),
-                Command::from_coap_resource("/.well-known/core", "Query the wkc"),
-                Wkc::cmd(),
-            ],
-            stored_cmds: all_commands(),
-        }
-    }
-
-    /// Takes a list of endpoints that are available, this is typically the list received
-    /// from /.well-known/core, goes through all `.stored_cmds` and sees if of any of them
-    /// the requirements are met. If so, they are added to the available `.cmds`
-    /// Finally, the available `.cmds` are re-sorted.
-    pub fn update_available_cmds_based_on_endpoints(&mut self, eps: &[String]) {
-        let mut i = 0;
-        while i < self.stored_cmds.len() {
-            let scmd = &self.stored_cmds[i];
-            // Todo: Commands should be able to decide on their own if they are available
-            if scmd.required_endpoints.iter().all(|ep| eps.contains(ep)) {
-                self.cmds.push(self.stored_cmds.remove(i));
-            } else {
-                i += 1;
-            }
-        }
-
-        self.cmds.sort();
-    }
-
-    /// Returns a list of the `Command.cmd` of all known `Command`s
-    pub fn list_by_cmd(&self) -> Vec<String> {
-        self.cmds.iter().map(|x| x.cmd.clone()).collect()
-    }
-
-    /// Adds a `Command`
-    pub fn add(&mut self, cmd: Command) {
-        self.cmds.push(cmd);
-    }
-
-    /// Returns all `Command`s whos `.cmd` matches the given prefix
-    pub fn matching_prefix_by_cmd(&self, prefix: &str) -> Vec<&Command> {
-        self.cmds
-            .iter()
-            .filter(|known_cmd| known_cmd.starts_with(prefix))
-            .collect()
-    }
-
-    /// Takes a given prefix, computes all `Command`s that match it.
-    /// The prefix is then prolonged as long as the list of matching `Command`s stays identical
-    /// For example if the given prefix `F` matches `FooBar`, `FooBaz` and `FooBizz`, this
-    /// function would return '`(FooB, [FooBar, FooBaz, FooBizz])`'
-    pub fn longest_common_prefixed_by_cmd(&self, prefix: &str) -> (String, Vec<&Command>) {
-        let cmds = self.matching_prefix_by_cmd(prefix);
-
-        let actual_prefix = match cmds.len() {
-            0 => prefix.to_owned(),
-            1 => cmds[0].cmd.clone(),
-            _ => {
-                let mut common_prefix = prefix.to_owned();
-                let first_cmd = &cmds[0].cmd;
-                'outer: for (i, character) in first_cmd.chars().enumerate().skip(prefix.len()) {
-                    for othercmd in cmds.iter().skip(1) {
-                        if i >= othercmd.cmd.len() || othercmd.cmd.chars().nth(i) != Some(character)
-                        {
-                            break 'outer;
-                        }
-                    }
-                    common_prefix.push(character);
-                }
-                common_prefix
-            }
-        };
-        (actual_prefix, cmds)
-    }
-
-    /// Finds the `Command` whose `cmd` matches exactly the input
-    pub fn find_by_cmd(&self, cmd: &str) -> Option<&Command> {
-        let cmd_clean = cmd.trim_ascii_end();
-        self.cmds
-            .iter()
-            .find(|known_cmd| known_cmd.cmd == cmd_clean)
-    }
-
-    /// Finds the `Command` whose `cmd` matches exactly the input, returns mutable
-    pub fn find_by_cmd_mut(&mut self, cmd: &str) -> Option<&mut Command> {
-        let cmd_clean = cmd.trim_ascii_end();
-        self.cmds
-            .iter_mut()
-            .find(|known_cmd| known_cmd.cmd == cmd_clean)
-    }
-
-    /// Finds the `Command` whose `location` matches exactly the input
-    pub fn find_by_first_location(&self, location: &str) -> Option<&Command> {
-        self.cmds.iter().find(|known_cmd| {
-            known_cmd
-                .required_endpoints
-                .first()
-                .is_some_and(|l| l == location)
-        })
-    }
-
-    /// Same as `find_by_location` but returns a mutable
-    pub fn find_by_first_location_mut(&mut self, location: &str) -> Option<&mut Command> {
-        self.cmds.iter_mut().find(|known_cmd| {
-            known_cmd
-                .required_endpoints
-                .first()
-                .is_some_and(|l| l == location)
-        })
-    }
-
-    /// Checks is a given `Command` is already in the library
-    pub fn _contains(&self, cmd: &Command) -> bool {
-        for known_cmd in &self.cmds {
-            if known_cmd == cmd {
-                return true;
-            }
-        }
-        false
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::events::Event;
 use crate::slipmux::create_slipmux_thread;
 
 mod app;
-mod commands;
+mod command;
 mod events;
 mod slipmux;
 mod transport;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod command;
 mod events;
 mod slipmux;
 mod transport;
+mod tui;
 
 type EventChannel = (Sender<Event>, Receiver<Event>);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,168 @@
+use tui_widgets::scrollview::ScrollViewState;
+
+mod render;
+
+#[derive(Default, Clone, Copy)]
+enum SelectedTab {
+    #[default]
+    Overview,
+    Diagnostic,
+    Configuration,
+    Commands,
+    Help,
+}
+
+struct ScrollState {
+    state: ScrollViewState,
+    position: usize,
+    follow: bool,
+}
+
+impl ScrollState {
+    fn new() -> Self {
+        Self {
+            state: ScrollViewState::default(),
+            position: 0,
+            follow: true,
+        }
+    }
+
+    fn scroll_down(&mut self) {
+        self.position = self.position.saturating_sub(1);
+        // When scrolled all the way to the bottom, auto follow the feed ("sticky behavior")
+        self.follow = self.position == 0;
+        self.state.scroll_down();
+    }
+
+    fn scroll_up(&mut self) {
+        self.follow = false;
+        // Can't scroll up when already on top
+        if self.state.offset().y != 0 {
+            self.position = self.position.saturating_add(1);
+        }
+        self.state.scroll_up();
+    }
+
+    fn get_state_for_rendering(&mut self) -> &mut ScrollViewState {
+        // For the "sticky" behavior, where the view remains at the bottom
+        // Needs to be done during rendering as more content could have been added, making
+        // a jump to the bottom necessary
+        if self.follow {
+            self.state.scroll_to_bottom();
+        }
+
+        &mut self.state
+    }
+}
+
+pub struct UiState {
+    device_path: Option<String>,
+    overview_scroll: ScrollState,
+    diagnostic_scroll: ScrollState,
+    configuration_scroll: ScrollState,
+    command_scroll: ScrollState,
+    help_scroll: ScrollState,
+    current_tab: SelectedTab,
+    riot_board: String,
+    riot_version: String,
+}
+
+impl UiState {
+    pub fn new() -> Self {
+        Self {
+            device_path: None,
+
+            current_tab: SelectedTab::Overview,
+
+            overview_scroll: ScrollState::new(),
+            diagnostic_scroll: ScrollState::new(),
+            configuration_scroll: ScrollState::new(),
+            command_scroll: ScrollState::new(),
+            help_scroll: ScrollState::new(),
+
+            riot_board: "Unkown".to_owned(),
+            riot_version: "Unkown".to_owned(),
+        }
+    }
+
+    pub fn set_board_name(&mut self, name: String) {
+        self.riot_board = name;
+    }
+
+    pub fn set_board_version(&mut self, version: String) {
+        self.riot_version = version;
+    }
+
+    pub fn set_device_path(&mut self, path: String) {
+        self.device_path = Some(path);
+    }
+
+    pub fn clear_device_path(&mut self) {
+        self.device_path = None;
+    }
+
+    fn get_config(&self) -> String {
+        format!(
+            "Version: {}\nBoard: {}\n",
+            self.riot_version, self.riot_board,
+        )
+    }
+
+    fn get_connection(&self) -> String {
+        match &self.device_path {
+            Some(device_path) => {
+                format!(
+                    "✅ connected via {device_path} with RIOT {}",
+                    self.riot_version
+                )
+            }
+            None => "❌ not connected, retrying..".to_owned(),
+        }
+    }
+
+    pub fn scroll_down(&mut self) {
+        match self.current_tab {
+            SelectedTab::Overview => {
+                self.overview_scroll.scroll_down();
+                self.configuration_scroll.scroll_down();
+            }
+            SelectedTab::Diagnostic => self.diagnostic_scroll.scroll_down(),
+            SelectedTab::Configuration => self.configuration_scroll.scroll_down(),
+            SelectedTab::Commands => self.command_scroll.scroll_down(),
+            SelectedTab::Help => self.help_scroll.scroll_down(),
+        }
+    }
+
+    pub fn scroll_up(&mut self) {
+        match self.current_tab {
+            SelectedTab::Overview => {
+                self.overview_scroll.scroll_up();
+                self.configuration_scroll.scroll_up();
+            }
+            SelectedTab::Diagnostic => self.diagnostic_scroll.scroll_up(),
+            SelectedTab::Configuration => self.configuration_scroll.scroll_up(),
+            SelectedTab::Commands => self.command_scroll.scroll_up(),
+            SelectedTab::Help => self.help_scroll.scroll_up(),
+        }
+    }
+
+    pub const fn select_overview_view(&mut self) {
+        self.current_tab = SelectedTab::Overview;
+    }
+
+    pub const fn select_diagnostic_view(&mut self) {
+        self.current_tab = SelectedTab::Diagnostic;
+    }
+
+    pub const fn select_configuration_view(&mut self) {
+        self.current_tab = SelectedTab::Configuration;
+    }
+
+    pub const fn select_commands_view(&mut self) {
+        self.current_tab = SelectedTab::Commands;
+    }
+
+    pub const fn select_help_view(&mut self) {
+        self.current_tab = SelectedTab::Help;
+    }
+}


### PR DESCRIPTION
In the future®, various ways of using Jelly could be abstracted via custom app + rendering. In order to re-use the very core-logic that most will share the app struct needs to get stripped of aspects that are only TUI related. This is step one. Splitting out Tui state, command library and rendering.