### PR TITLE
coap: Don't request block-wise transfer

### DIFF
--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -204,7 +204,6 @@ impl App {
                     request.set_path(&endpoint);
                 }
                 request.message.set_token(self.get_new_token());
-                request.message.add_option(CoapOption::Block2, vec![0x05]);
                 let data =
                     encode_buffered(Slipmux::Configuration(request.message.to_bytes().unwrap()));
                 self.event_sender

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -94,7 +94,6 @@ impl App {
     fn send_configuration_request(&mut self, msg: &mut Packet) {
         msg.header.message_id = self.get_new_message_id();
         msg.set_token(self.get_new_token());
-        msg.add_option(CoapOption::Block2, vec![0x05]);
 
         let data = encode_buffered(Slipmux::Configuration(msg.to_bytes().unwrap()));
         self.event_sender


### PR DESCRIPTION
Unconditionally adding a Block2 option interferes with non-GET requests -- but AIU the need for this workaround has gone away when jelly went from slipmux-0.2 to later versions that don't have the fixed 256 byte buffer any more. (Generally in CoAP, the block size is safely negotiated on demand as long as the receiver can know when it received truncated packets; Jelly is unconstrained, so it doesn't need to use small buffers).