### PR TITLE
💥 commands: Pass full CoAP response instead of just payload

### DIFF
--- a/src/app/datatypes.rs
+++ b/src/app/datatypes.rs
@@ -9,6 +9,7 @@ use coap_lite::CoapRequest;
 use coap_lite::CoapResponse;
 use coap_lite::ContentFormat;
 use coap_lite::MessageClass;
+use coap_lite::Packet;
 use ratatui::prelude::Alignment;
 use ratatui::prelude::Stylize;
 use ratatui::style::Style;
@@ -167,12 +168,12 @@ impl JobLog {
         Self { jobs: vec![] }
     }
 
-    pub fn job_handle_payload(
+    pub fn job_handle_response(
         &mut self,
         job_id: usize,
-        payload: &[u8],
+        response: &Packet,
     ) -> Option<CoapRequest<String>> {
-        self.jobs[job_id].handler.as_mut().unwrap().handle(payload)
+        self.jobs[job_id].handler.as_mut().unwrap().handle(response)
     }
 
     pub fn job_wants_display(&self, job_id: usize) -> bool {

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -86,11 +86,11 @@ impl App {
         self.ui_state.clear_device_path();
     }
 
-    fn handle_pending_job(&mut self, mut hash_index: u64, payload: &[u8]) {
+    fn handle_pending_job(&mut self, mut hash_index: u64, response: &Packet) {
         // Do we have a job / handler for this request?
         // Removes it from the job list here
         if let Some(job_id) = self.ongoing_jobs.remove(&hash_index) {
-            let maybe_request = self.job_log.job_handle_payload(job_id, payload);
+            let maybe_request = self.job_log.job_handle_response(job_id, response);
             if self.job_log.job_wants_display(job_id) {
                 let buffer = self.job_log.job_display(job_id);
                 self.overall_log.add(&buffer);
@@ -124,7 +124,7 @@ impl App {
 
         // Do we have a job / handler for this request?
         // Removes it from the job list if finished
-        self.handle_pending_job(hash_index, &response.payload);
+        self.handle_pending_job(hash_index, &response);
 
         let found_matching_request = self
             .configuration_log

--- a/src/command/commands/mem.rs
+++ b/src/command/commands/mem.rs
@@ -1,8 +1,8 @@
 use std::fmt::Write;
 
 use clap::Parser;
-use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
+use coap_lite::{CoapRequest, Packet};
 use coap_message::MinimalWritableMessage;
 use minicbor::Decoder;
 use minicbor::Encoder;
@@ -129,8 +129,8 @@ impl CommandHandler for MemRead {
         self.send_request()
     }
 
-    fn handle(&mut self, payload: &[u8]) -> Option<CoapRequest<String>> {
-        let mut decoder = Decoder::new(payload);
+    fn handle(&mut self, response: &Packet) -> Option<CoapRequest<String>> {
+        let mut decoder = Decoder::new(&response.payload);
         if let Ok(bytes) = decoder.bytes() {
             self.buffer.extend_from_slice(bytes);
         }

--- a/src/command/commands/multi_endpoints_sample.rs
+++ b/src/command/commands/multi_endpoints_sample.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
-use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
+use coap_lite::{CoapRequest, Packet};
 
 use super::Command;
 use super::CommandHandler;
@@ -48,12 +48,12 @@ impl CommandHandler for MultiEndpointSample {
         request
     }
 
-    fn handle(&mut self, payload: &[u8]) -> Option<CoapRequest<String>> {
+    fn handle(&mut self, response: &Packet) -> Option<CoapRequest<String>> {
+        let decoded = String::from_utf8_lossy(&response.payload);
+
         match self.state_machine {
             0 => {
-                self.buffer += &String::from_utf8_lossy(payload)
-                    .to_string()
-                    .replace(',', "\n");
+                self.buffer += &decoded.replace(',', "\n");
                 self.buffer += "\n";
 
                 let mut request: CoapRequest<String> = CoapRequest::new();
@@ -64,9 +64,7 @@ impl CommandHandler for MultiEndpointSample {
                 Some(request)
             }
             1 => {
-                self.buffer += &String::from_utf8_lossy(payload)
-                    .to_string()
-                    .replace(',', "\n");
+                self.buffer += &decoded.replace(',', "\n");
                 self.buffer += "\n";
 
                 let mut request: CoapRequest<String> = CoapRequest::new();
@@ -77,9 +75,7 @@ impl CommandHandler for MultiEndpointSample {
                 Some(request)
             }
             _ => {
-                self.buffer += &String::from_utf8_lossy(payload)
-                    .to_string()
-                    .replace(',', "\n");
+                self.buffer += &decoded.replace(',', "\n");
                 self.buffer += "\n";
 
                 self.buffer += "==== Done! ====\n";

--- a/src/command/commands/ps.rs
+++ b/src/command/commands/ps.rs
@@ -3,8 +3,8 @@ use std::fmt::Formatter;
 use std::fmt::Write;
 
 use clap::Parser;
-use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
+use coap_lite::{CoapRequest, Packet};
 use minicbor::Decoder;
 
 use super::Command;
@@ -117,10 +117,10 @@ impl CommandHandler for Ps {
         request
     }
 
-    fn handle(&mut self, payload: &[u8]) -> Option<CoapRequest<String>> {
-        self.payload = payload.to_vec();
+    fn handle(&mut self, response: &Packet) -> Option<CoapRequest<String>> {
+        self.payload.clone_from(&response.payload);
         let mut out = String::new();
-        let mut decoder = Decoder::new(payload);
+        let mut decoder = Decoder::new(&self.payload);
         let mut sum_stack = 0;
         let mut sum_stack_used = 0;
         let mut sum_stack_free = 0;

--- a/src/command/commands/sample.rs
+++ b/src/command/commands/sample.rs
@@ -1,8 +1,8 @@
 use std::fmt::Write;
 
 use clap::Parser;
-use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
+use coap_lite::{CoapRequest, Packet};
 use coap_message::MinimalWritableMessage;
 use minicbor::Encoder;
 
@@ -78,8 +78,8 @@ impl CommandHandler for SampleCommand {
         request
     }
 
-    fn handle(&mut self, payload: &[u8]) -> Option<CoapRequest<String>> {
-        self.buffer = String::from_utf8_lossy(payload).to_string();
+    fn handle(&mut self, response: &Packet) -> Option<CoapRequest<String>> {
+        self.buffer = String::from_utf8_lossy(&response.payload).to_string();
         self.buffer = self.buffer.replace(',', "\n");
         self.finished = true;
         self.displayable = true;

--- a/src/command/commands/saul.rs
+++ b/src/command/commands/saul.rs
@@ -2,8 +2,8 @@ use std::fmt::Write;
 
 use clap::Parser;
 use clap::Subcommand;
-use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
+use coap_lite::{CoapRequest, Packet};
 use coap_message::MinimalWritableMessage;
 use minicbor::Decoder;
 use minicbor::Encoder;
@@ -100,14 +100,14 @@ impl CommandHandler for Saul {
         request
     }
 
-    fn handle(&mut self, payload: &[u8]) -> Option<CoapRequest<String>> {
-        self.payload = payload.to_vec();
+    fn handle(&mut self, response: &Packet) -> Option<CoapRequest<String>> {
+        self.payload.clone_from(&response.payload);
         let mut out = String::new();
-        let mut decoder = Decoder::new(payload);
+        let mut decoder = Decoder::new(&self.payload);
 
         match self.cli.operation {
             None => {
-                out = decode_sensor_list_into_string(payload);
+                out = decode_sensor_list_into_string(&self.payload);
             }
             Some(SaulOperation::Read { id }) => {
                 let data = decoder.map();

--- a/src/command/commands/wkc.rs
+++ b/src/command/commands/wkc.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
-use coap_lite::CoapRequest;
 use coap_lite::RequestType as Method;
+use coap_lite::{CoapRequest, Packet};
 
 use super::Command;
 use super::CommandHandler;
@@ -44,8 +44,8 @@ impl CommandHandler for Wkc {
         request
     }
 
-    fn handle(&mut self, payload: &[u8]) -> Option<CoapRequest<String>> {
-        self.buffer = String::from_utf8_lossy(payload).to_string();
+    fn handle(&mut self, response: &Packet) -> Option<CoapRequest<String>> {
+        self.buffer = String::from_utf8_lossy(&response.payload).to_string();
         self.buffer = self.buffer.replace(',', "\n");
         self.finished = true;
         self.displayable = true;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use coap_lite::CoapRequest;
+use coap_lite::{CoapRequest, Packet};
 
 use commands::CoapGet;
 pub use library::CommandLibrary;
@@ -15,7 +15,7 @@ pub trait CommandHandler {
     fn init(&mut self) -> CoapRequest<String>;
 
     /// Called everytime a response is found to the last request this handler has sent.
-    fn handle(&mut self, _payload: &[u8]) -> Option<CoapRequest<String>> {
+    fn handle(&mut self, _payload: &Packet) -> Option<CoapRequest<String>> {
         None
     }
 


### PR DESCRIPTION
As discussed, passing full responses would be useful, especially for commands where the response payload just doesn't tell the full message.

Most changes are really mechanical; in one place (multi_endpoints_sample), I think the added struct member accessor would tip my balance for code duplication, so I factored the string decoding out of the match.