### PR TITLE
feat: Let command decide how to act it / which type it is

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -64,6 +64,26 @@ impl App {
 
     pub fn force_all_commands_availabe(&mut self) {
         self.user_input_manager.force_all_commands_availabe();
+        self.populate_command_help_list();
+    }
+
+    fn populate_command_help_list(&mut self) {
+        let cmd_list = self
+            .user_input_manager
+            .known_commands
+            .list_available_commands();
+
+        // Vec<(Name, Description, Help)>
+        let err_list = cmd_list
+            .into_iter()
+            .map(|cmd| {
+                (cmd.parse)(cmd, &format!("{:} --help", cmd.cmd)).map_or_else(
+                    |x| (cmd.cmd.clone(), cmd.description.clone(), x),
+                    |_| (cmd.cmd.clone(), cmd.description.clone(), String::new()),
+                )
+            })
+            .collect::<Vec<_>>();
+        self.ui_state.set_command_help_list(err_list);
     }
 
     pub fn unfinished_jobs_count(&self) -> usize {

--- a/src/command/commands/coap_get_template.rs
+++ b/src/command/commands/coap_get_template.rs
@@ -7,7 +7,7 @@ use super::CommandHandler;
 /// This is a template command. It shows the minimum setup for making a
 /// CoAP GET request to a single endpoint. The result is not displayed to the user.
 /// Allthought the default overview of received CoAP responses will show a summary.
-/// This is used make all endpoints in the /.well-known/core available for a
+/// This is used to make all endpoints in the /.well-known/core available for a
 /// quick get request via autocomplete.
 pub struct CoapGet(String);
 

--- a/src/command/commands/mem.rs
+++ b/src/command/commands/mem.rs
@@ -9,6 +9,7 @@ use minicbor::Encoder;
 
 use super::Command;
 use super::CommandHandler;
+use super::CommandType;
 
 /// Taken and modified from Alex Martens's clap-num
 /// <https://github.com/newAM/clap-num/blob/c6f1065f87f319098943aae75412a0c38c85f11c/src/lib.rs#L347-L384>
@@ -77,14 +78,14 @@ impl MemRead {
         }
     }
 
-    fn parse(_cmd: &Command, args: &str) -> Result<Box<dyn CommandHandler>, String> {
+    fn parse(_cmd: &Command, args: &str) -> Result<CommandType, String> {
         let cli = MemReadCli::try_parse_from(args.split_whitespace()).map_err(|e| e.to_string())?;
-        Ok(Box::new(Self {
+        Ok(CommandType::CoAP(Box::new(Self {
             buffer: Vec::new(),
             finished: false,
             displayable: false,
             cli,
-        }))
+        })))
     }
 
     fn send_request(&mut self) -> CoapRequest<String> {

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -7,6 +7,7 @@ pub use wkc::Wkc;
 
 use super::Command;
 use super::CommandHandler;
+use super::CommandType;
 
 mod coap_get_template;
 mod mem;
@@ -21,5 +22,13 @@ pub fn all_commands() -> Vec<Command> {
         MultiEndpointSample::cmd(),
         MemRead::cmd(),
         Ps::cmd(),
+        Wkc::cmd(),
+        Command::new_text_type("help", "Prints all available commands"),
+        Command::new_coap_get("/.well-known/core", "Query the wkc"),
+        Command::new_jelly_type("Help", "Jelly Help"),
+        Command::new_jelly_type(
+            "ForceCmdsAvailable",
+            "Enables all implemented commands disregarding their requirements",
+        ),
     ]
 }

--- a/src/command/commands/multi_endpoints_sample.rs
+++ b/src/command/commands/multi_endpoints_sample.rs
@@ -5,6 +5,7 @@ use coap_lite::{CoapRequest, Packet};
 
 use super::Command;
 use super::CommandHandler;
+use super::CommandType;
 
 /// This is an example for writing a command that needs to issue multiple CoAP requests and
 /// keep track of the state while doing so.
@@ -20,7 +21,7 @@ impl MultiEndpointSample {
         Command {
             cmd: "MultiEndpointSample".to_owned(),
             description: "Query multiple endpoints at once!".to_owned(),
-            parse: |c, a| Ok(Self::parse(c, a)),
+            parse: |c, a| Ok(CommandType::CoAP(Self::parse(c, a))),
             required_endpoints: vec![
                 "/jelly/board".to_owned(),
                 "/shell/reboot".to_owned(),

--- a/src/command/commands/ps.rs
+++ b/src/command/commands/ps.rs
@@ -9,6 +9,7 @@ use minicbor::Decoder;
 
 use super::Command;
 use super::CommandHandler;
+use super::CommandType;
 
 /// This is an example on how to use cbor as payload for the coap request.
 #[derive(Parser, Debug)]
@@ -36,15 +37,15 @@ impl Ps {
         }
     }
 
-    fn parse(cmd: &Command, args: &str) -> Result<Box<dyn CommandHandler>, String> {
+    fn parse(cmd: &Command, args: &str) -> Result<CommandType, String> {
         let _cli = PsCli::try_parse_from(args.split_whitespace()).map_err(|e| e.to_string())?;
-        Ok(Box::new(Self {
+        Ok(CommandType::CoAP(Box::new(Self {
             location: cmd.required_endpoints[0].clone(),
             buffer: String::new(),
             payload: vec![],
             finished: false,
             displayable: false,
-        }))
+        })))
     }
 }
 

--- a/src/command/commands/saul.rs
+++ b/src/command/commands/saul.rs
@@ -10,6 +10,7 @@ use minicbor::Encoder;
 
 use super::Command;
 use super::CommandHandler;
+use super::CommandType;
 
 /// This is an example on how to use cbor as payload for the coap request.
 #[derive(Parser, Debug)]
@@ -51,16 +52,16 @@ impl Saul {
         }
     }
 
-    fn parse(cmd: &Command, args: &str) -> Result<Box<dyn CommandHandler>, String> {
+    fn parse(cmd: &Command, args: &str) -> Result<CommandType, String> {
         let cli = SaulCli::try_parse_from(args.split_whitespace()).map_err(|e| e.to_string())?;
-        Ok(Box::new(Self {
+        Ok(CommandType::CoAP(Box::new(Self {
             location: cmd.required_endpoints[0].clone(),
             buffer: String::new(),
             payload: vec![],
             finished: false,
             displayable: false,
             cli,
-        }))
+        })))
     }
 }
 

--- a/src/command/commands/wkc.rs
+++ b/src/command/commands/wkc.rs
@@ -5,6 +5,7 @@ use coap_lite::{CoapRequest, Packet};
 
 use super::Command;
 use super::CommandHandler;
+use super::CommandType;
 
 /// Explicit example for a command that queries the well-known/core. Could have been done
 /// using the template command, but explicit for demonstration.
@@ -20,7 +21,7 @@ impl Wkc {
         Command {
             cmd: "Wkc".to_owned(),
             description: "Query the wkc".to_owned(),
-            parse: |c, a| Ok(Self::parse(c, a)),
+            parse: |c, a| Ok(CommandType::CoAP(Self::parse(c, a))),
             required_endpoints: vec!["/.well-known/core".to_owned()],
         }
     }

--- a/src/command/library.rs
+++ b/src/command/library.rs
@@ -1,5 +1,4 @@
 use super::commands::all_commands;
-use super::commands::Wkc;
 use super::Command;
 
 /// The command library maintains all known commands and provides easy access to them
@@ -15,11 +14,7 @@ impl CommandLibrary {
     /// - /.well-known/core: Query the wkc
     pub fn default() -> Self {
         Self {
-            cmds: vec![
-                Command::new("help", "Prints all available commands"),
-                Command::from_coap_resource("/.well-known/core", "Query the wkc"),
-                Wkc::cmd(),
-            ],
+            cmds: vec![],
             stored_cmds: all_commands(),
         }
     }
@@ -54,6 +49,10 @@ impl CommandLibrary {
     /// Returns a list of the `Command.cmd` of all known `Command`s
     pub fn list_by_cmd(&self) -> Vec<String> {
         self.cmds.iter().map(|x| x.cmd.clone()).collect()
+    }
+
+    pub fn list_available_commands(&self) -> Vec<&Command> {
+        self.cmds.iter().collect()
     }
 
     /// Adds a `Command`

--- a/src/tui/ui_state.rs
+++ b/src/tui/ui_state.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use tui_widgets::scrollview::ScrollViewState;
 
 #[derive(Default, Clone, Copy)]
@@ -61,6 +62,7 @@ pub struct UiState {
     pub command_scroll: ScrollState,
     pub help_scroll: ScrollState,
     pub current_tab: SelectedTab,
+    pub command_help_list: String,
     riot_board: String,
     riot_version: String,
 }
@@ -78,8 +80,24 @@ impl UiState {
             command_scroll: ScrollState::new(),
             help_scroll: ScrollState::new(),
 
+            command_help_list: String::new(),
+
             riot_board: "Unkown".to_owned(),
             riot_version: "Unkown".to_owned(),
+        }
+    }
+
+    pub fn set_command_help_list(&mut self, cmds: Vec<(String, String, String)>) {
+        self.command_help_list.clear();
+        for (cmd, description, help) in cmds {
+            if help.is_empty() {
+                let _ = writeln!(self.command_help_list, "{cmd:<20}: {description}");
+            } else {
+                let _ = writeln!(
+                    self.command_help_list,
+                    "{cmd:<20}: {description} | see --help for more information"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Hello,

this adds a wrapping enum to the parse function of the Commands. The idea is to cleanup the separation between Diagnostic-only and coap-based commands. In addition, this can be the foundation for "Jelly Internal" commands. It also hints at the possibility to later have "Network-based" commands, once the Packet channel of slipmux is used. 

Just a draft. Needs more thinking.